### PR TITLE
feat: Implement Cross-settlement for N-party debts

### DIFF
--- a/src/main/java/dev/coms4156/project/groupproject/controller/LedgerController.java
+++ b/src/main/java/dev/coms4156/project/groupproject/controller/LedgerController.java
@@ -77,4 +77,10 @@ public class LedgerController {
     ledgerService.removeMember(ledgerId, userId);
     return Result.ok();
   }
+
+  @GetMapping("/{ledgerId}/settlement-plan")
+  @Operation(summary = "Get minimal settlement plan for N-party debts")
+  public Result<SettlementPlanResponse> getSettlementPlan(@PathVariable Long ledgerId) {
+    return Result.ok(ledgerService.getSettlementPlan(ledgerId));
+  }
 }

--- a/src/main/java/dev/coms4156/project/groupproject/dto/SettlementPlanResponse.java
+++ b/src/main/java/dev/coms4156/project/groupproject/dto/SettlementPlanResponse.java
@@ -1,0 +1,49 @@
+package dev.coms4156.project.groupproject.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Response for settlement plan showing minimal transfer list to settle all debts. */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Settlement plan with minimal transfers to settle all debts")
+public class SettlementPlanResponse {
+  @Schema(description = "Ledger ID", example = "456")
+  private Long ledgerId;
+
+  @Schema(description = "Currency of the settlement", example = "USD")
+  private String currency;
+
+  @Schema(description = "Total number of transfers in the plan", example = "3")
+  private Integer transferCount;
+
+  @Schema(description = "List of transfer instructions (who pays whom how much)")
+  private List<TransferItem> transfers;
+
+  /** Represents a single transfer in the settlement plan. */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "Single transfer instruction")
+  public static class TransferItem {
+    @Schema(description = "Payer user ID (who pays)", example = "222")
+    private Long fromUserId;
+
+    @Schema(description = "Payer user name", example = "Bob")
+    private String fromUserName;
+
+    @Schema(description = "Receiver user ID (who receives)", example = "111")
+    private Long toUserId;
+
+    @Schema(description = "Receiver user name", example = "Alice")
+    private String toUserName;
+
+    @Schema(description = "Transfer amount (always positive)", example = "25.50")
+    private BigDecimal amount;
+  }
+}

--- a/src/main/java/dev/coms4156/project/groupproject/service/LedgerService.java
+++ b/src/main/java/dev/coms4156/project/groupproject/service/LedgerService.java
@@ -7,6 +7,7 @@ import dev.coms4156.project.groupproject.dto.LedgerMemberResponse;
 import dev.coms4156.project.groupproject.dto.LedgerResponse;
 import dev.coms4156.project.groupproject.dto.ListLedgerMembersResponse;
 import dev.coms4156.project.groupproject.dto.MyLedgersResponse;
+import dev.coms4156.project.groupproject.dto.SettlementPlanResponse;
 import dev.coms4156.project.groupproject.entity.Ledger;
 
 /** Service for ledger-related operations. */
@@ -22,4 +23,6 @@ public interface LedgerService extends IService<Ledger> {
   ListLedgerMembersResponse listMembers(Long ledgerId);
 
   void removeMember(Long ledgerId, Long userId);
+
+  SettlementPlanResponse getSettlementPlan(Long ledgerId);
 }

--- a/src/main/java/dev/coms4156/project/groupproject/service/impl/LedgerServiceImpl.java
+++ b/src/main/java/dev/coms4156/project/groupproject/service/impl/LedgerServiceImpl.java
@@ -8,17 +8,25 @@ import dev.coms4156.project.groupproject.dto.LedgerMemberResponse;
 import dev.coms4156.project.groupproject.dto.LedgerResponse;
 import dev.coms4156.project.groupproject.dto.ListLedgerMembersResponse;
 import dev.coms4156.project.groupproject.dto.MyLedgersResponse;
+import dev.coms4156.project.groupproject.dto.SettlementPlanResponse;
 import dev.coms4156.project.groupproject.dto.UserView;
+import dev.coms4156.project.groupproject.entity.DebtEdge;
 import dev.coms4156.project.groupproject.entity.Ledger;
 import dev.coms4156.project.groupproject.entity.LedgerMember;
 import dev.coms4156.project.groupproject.entity.User;
+import dev.coms4156.project.groupproject.mapper.DebtEdgeMapper;
 import dev.coms4156.project.groupproject.mapper.LedgerMapper;
 import dev.coms4156.project.groupproject.mapper.LedgerMemberMapper;
 import dev.coms4156.project.groupproject.mapper.UserMapper;
 import dev.coms4156.project.groupproject.service.LedgerService;
 import dev.coms4156.project.groupproject.utils.AuthUtils;
 import dev.coms4156.project.groupproject.utils.CurrentUserContext;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -30,11 +38,14 @@ public class LedgerServiceImpl extends ServiceImpl<LedgerMapper, Ledger> impleme
 
   private final LedgerMemberMapper ledgerMemberMapper;
   private final UserMapper userMapper;
+  private final DebtEdgeMapper debtEdgeMapper;
 
   @Autowired
-  public LedgerServiceImpl(LedgerMemberMapper ledgerMemberMapper, UserMapper userMapper) {
+  public LedgerServiceImpl(
+      LedgerMemberMapper ledgerMemberMapper, UserMapper userMapper, DebtEdgeMapper debtEdgeMapper) {
     this.ledgerMemberMapper = ledgerMemberMapper;
     this.userMapper = userMapper;
+    this.debtEdgeMapper = debtEdgeMapper;
   }
 
   @Override
@@ -228,5 +239,142 @@ public class LedgerServiceImpl extends ServiceImpl<LedgerMapper, Ledger> impleme
 
   private boolean isMember(Long ledgerId, Long userId) {
     return getLedgerMember(ledgerId, userId) != null;
+  }
+
+  @Override
+  public SettlementPlanResponse getSettlementPlan(Long ledgerId) {
+    UserView currentUser = CurrentUserContext.get();
+    if (currentUser == null) {
+      throw new RuntimeException("AUTH_REQUIRED");
+    }
+
+    Ledger ledger = getById(ledgerId);
+    if (ledger == null) {
+      throw new RuntimeException("LEDGER_NOT_FOUND");
+    }
+
+    AuthUtils.checkMembership(isMember(ledgerId, currentUser.getId()));
+
+    List<DebtEdge> allEdges = debtEdgeMapper.findByLedgerId(ledgerId);
+
+    Map<Long, BigDecimal> netBalances = calculateNetBalances(allEdges);
+
+    List<SettlementPlanResponse.TransferItem> transfers =
+        generateMinimalSettlementPlan(netBalances);
+
+    return new SettlementPlanResponse(
+        ledgerId, ledger.getBaseCurrency(), transfers.size(), transfers);
+  }
+
+  /**
+   * Calculate net balances from debt edges, handling symmetry (b requirement). If A owes B 20 and B
+   * owes A 40, the net becomes B owes A 20.
+   *
+   * @param edges all debt edges for the ledger
+   * @return map of user ID to net balance (positive = creditor, negative = debtor)
+   */
+  private Map<Long, BigDecimal> calculateNetBalances(List<DebtEdge> edges) {
+    Map<Long, BigDecimal> balances = new HashMap<>();
+
+    for (DebtEdge edge : edges) {
+      Long creditorId = edge.getFromUserId();
+      Long debtorId = edge.getToUserId();
+      BigDecimal amount = edge.getAmount();
+
+      balances.put(creditorId, balances.getOrDefault(creditorId, BigDecimal.ZERO).add(amount));
+      balances.put(debtorId, balances.getOrDefault(debtorId, BigDecimal.ZERO).subtract(amount));
+    }
+
+    return balances;
+  }
+
+  /**
+   * Generate minimal settlement plan using heap-greedy algorithm (a requirement). Matches largest
+   * creditors with largest debtors to minimize number of transfers.
+   *
+   * @param netBalances map of user ID to net balance
+   * @return list of transfer instructions (who pays whom how much)
+   */
+  private List<SettlementPlanResponse.TransferItem> generateMinimalSettlementPlan(
+      Map<Long, BigDecimal> netBalances) {
+
+    List<SettlementPlanResponse.TransferItem> transfers = new ArrayList<>();
+
+    PriorityQueue<BalanceEntry> creditors =
+        new PriorityQueue<>((a, b) -> b.getAmount().compareTo(a.getAmount()));
+    PriorityQueue<BalanceEntry> debtors =
+        new PriorityQueue<>((a, b) -> a.getAmount().compareTo(b.getAmount()));
+
+    Map<Long, User> userCache = new HashMap<>();
+
+    for (Map.Entry<Long, BigDecimal> entry : netBalances.entrySet()) {
+      BigDecimal balance = entry.getValue();
+      if (balance.compareTo(BigDecimal.ZERO) > 0) {
+        User user = userCache.computeIfAbsent(entry.getKey(), userMapper::selectById);
+        if (user != null) {
+          creditors.offer(new BalanceEntry(entry.getKey(), user.getName(), balance));
+        }
+      } else if (balance.compareTo(BigDecimal.ZERO) < 0) {
+        User user = userCache.computeIfAbsent(entry.getKey(), userMapper::selectById);
+        if (user != null) {
+          debtors.offer(new BalanceEntry(entry.getKey(), user.getName(), balance.abs()));
+        }
+      }
+    }
+
+    while (!creditors.isEmpty() && !debtors.isEmpty()) {
+      BalanceEntry creditor = creditors.poll();
+      BalanceEntry debtor = debtors.poll();
+
+      BigDecimal transferAmount = creditor.getAmount().min(debtor.getAmount());
+
+      SettlementPlanResponse.TransferItem transfer =
+          new SettlementPlanResponse.TransferItem(
+              debtor.getUserId(),
+              debtor.getUserName(),
+              creditor.getUserId(),
+              creditor.getUserName(),
+              transferAmount);
+      transfers.add(transfer);
+
+      BigDecimal remainingCreditor = creditor.getAmount().subtract(transferAmount);
+      BigDecimal remainingDebtor = debtor.getAmount().subtract(transferAmount);
+
+      if (remainingCreditor.compareTo(BigDecimal.ZERO) > 0) {
+        creditors.offer(
+            new BalanceEntry(creditor.getUserId(), creditor.getUserName(), remainingCreditor));
+      }
+
+      if (remainingDebtor.compareTo(BigDecimal.ZERO) > 0) {
+        debtors.offer(new BalanceEntry(debtor.getUserId(), debtor.getUserName(), remainingDebtor));
+      }
+    }
+
+    return transfers;
+  }
+
+  /** Helper class for balance entries used in priority queues. */
+  private static class BalanceEntry {
+    private final Long userId;
+    private final String userName;
+    private final BigDecimal amount;
+
+    BalanceEntry(Long userId, String userName, BigDecimal amount) {
+      this.userId = userId;
+      this.userName = userName;
+      this.amount = amount;
+    }
+
+    Long getUserId() {
+      return userId;
+    }
+
+    String getUserName() {
+      return userName;
+    }
+
+    BigDecimal getAmount() {
+      return amount;
+    }
   }
 }


### PR DESCRIPTION
Cross-settlement for N-party debts
a. Converts directed debts into minimal settlement plans via heap‑greedy (or
min‑cost flow for edge cases), considering constraints including caps, rounding,
and payment channels.
b. Handles symmetry: if A owes B 20 and B owes A 40, the net becomes B owes A
20 automatically.
c. The mentioned function also scales to groups with multiple members. When a list
of debt information is entered, the service returns a concrete list of transfers in the
form of who pays whom how much.